### PR TITLE
Adapt Check for mdbtools

### DIFF
--- a/slyr_community/bintools/extractor.py
+++ b/slyr_community/bintools/extractor.py
@@ -143,7 +143,7 @@ class Extractor:
                                   universal_newlines=True,
                                   **Extractor.get_process_keywords()) as proc:
                 for line in proc.stdout:
-                    if 'Usage' in line:
+                    if 'row-delimiter' in line:
                         return True
         except FileNotFoundError:
             pass


### PR DESCRIPTION
With system language settings other than english it can happen, that mdbtools output does not contain 'Usage'. Changing as discussed in #113

As a side note: I was not able to run the tests because of missing dependencies on my Mac.